### PR TITLE
Fix infinite mark as read effect loop

### DIFF
--- a/app/group/[groupId].tsx
+++ b/app/group/[groupId].tsx
@@ -15,11 +15,16 @@ const GroupChatScreen = () => {
     [getGroupById, groupId],
   );
 
+  const groupIdValue = group?.id;
+  const unreadCount = group?.unreadCount ?? 0;
+
   useEffect(() => {
-    if (group) {
-      markMessagesAsRead(group.id);
+    if (!groupIdValue || unreadCount === 0) {
+      return;
     }
-  }, [group, markMessagesAsRead]);
+
+    markMessagesAsRead(groupIdValue);
+  }, [groupIdValue, unreadCount, markMessagesAsRead]);
 
   if (!group) {
     return (


### PR DESCRIPTION
## Summary
- prevent the group chat screen effect from re-triggering endlessly by tracking the group id and unread count separately
- avoid repeated calls to markMessagesAsRead that caused the maximum update depth exceeded error

## Testing
- npm run lint *(fails: missing eslint-plugin-prettier dependency in the project setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d834e4f1c8832dad39882a14065202