### PR TITLE
Fix chat UI header visibility and bubble styling

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout() {
             <Stack>
               <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
               <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
-              <Stack.Screen name="group/[groupId]" options={{ headerShown: false }} />
+              <Stack.Screen name="group/[groupId]" options={{ headerShown: true }} />
             </Stack>
             <StatusBar style="auto" />
           </ThemeProvider>

--- a/app/group/[groupId].tsx
+++ b/app/group/[groupId].tsx
@@ -76,6 +76,7 @@ const GroupChatScreen = () => {
             </HStack>
           ),
           headerStyle: { backgroundColor: 'white' },
+          headerTintColor: '#0f172a',
         }}
       />
       <ChatView group={group} />

--- a/components/Chat-extended/chat-view/chat-view.tsx
+++ b/components/Chat-extended/chat-view/chat-view.tsx
@@ -51,6 +51,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ group }) => {
           messages={group.messages}
           currentUserId={currentUser.id}
           accentColor={group.accentColor}
+          participants={group.participants}
         />
       </ImageBackground>
       {typingNames ? (

--- a/components/Chat-extended/chat-view/composer/message-composer.tsx
+++ b/components/Chat-extended/chat-view/composer/message-composer.tsx
@@ -64,20 +64,30 @@ export const MessageComposer: React.FC<MessageComposerProps> = ({ onSend, accent
           bg="$backgroundLight200"
           borderRadius="$full"
           alignItems="center"
-          px="$2"
+          px="$3"
           py="$1"
           space="sm"
         >
           <Button variant="link" action="secondary" onPress={() => setIsSheetOpen(true)}>
             <ButtonIcon as={Paperclip} color="$mutedForeground" />
           </Button>
-          <Textarea flex={1} bg="$transparent" borderColor="$transparent">
+          <Textarea
+            flex={1}
+            bg="$transparent"
+            borderColor="$transparent"
+            borderWidth={0}
+            px="$0"
+            py="$0"
+            minHeight={40}
+            maxHeight={120}
+          >
             <TextareaInput
               value={text}
               onChangeText={setText}
               placeholder="Messaggio"
               color="$textDark900"
               multiline
+              style={{ minHeight: 36, maxHeight: 120, paddingVertical: 6, textAlignVertical: 'center' }}
             />
           </Textarea>
           <Button variant="link" action="secondary" onPress={() => handleAttachment('image')}>

--- a/components/Chat-extended/chat-view/messages/audio-message-bubble.tsx
+++ b/components/Chat-extended/chat-view/messages/audio-message-bubble.tsx
@@ -21,33 +21,48 @@ export const AudioMessageBubble: React.FC<AudioMessageBubbleProps> = ({
   message,
   isOwn,
   accentColor,
-}) => (
-  <MessageBubble
-    isOwnMessage={isOwn}
-    status={message.status}
-    timestamp={message.createdAt}
-    accentColor={accentColor}
-  >
-    <HStack alignItems="center" space="md">
-      <Box bg={isOwn ? 'rgba(255,255,255,0.25)' : '$success100'} borderRadius="$full" p="$2">
-        <Icon as={Play} size="sm" color={isOwn ? '$white' : '$success600'} />
-      </Box>
-      <VStack flex={1} space="sm">
-        <HStack alignItems="flex-end" space="xs">
-          {message.waveform?.slice(0, 20).map((value, index) => (
-            <Box
-              key={`${message.id}-wave-${index}`}
-              width={3}
-              borderRadius="$full"
-              bg={isOwn ? 'rgba(255,255,255,0.7)' : '$success500'}
-              height={Math.max(8, Math.min(28, value * 2))}
-            />
-          ))}
-        </HStack>
-        <Text color={isOwn ? '$white' : '$mutedForeground'} fontSize="$xs">
-          {formatDuration(message.durationSeconds)} • Voice message
-        </Text>
-      </VStack>
-    </HStack>
-  </MessageBubble>
-);
+}) => {
+  const iconWrapperBg = isOwn ? 'rgba(255,255,255,0.25)' : 'rgba(15, 23, 42, 0.08)';
+  const iconColor = isOwn ? '$white' : accentColor;
+  const trackBg = isOwn ? 'rgba(255,255,255,0.35)' : '$backgroundLight300';
+  const progressBg = isOwn ? '$white' : accentColor;
+  const secondaryTextColor = isOwn ? 'rgba(255,255,255,0.85)' : '$mutedForeground';
+  const primaryTextColor = isOwn ? '$white' : '$textDark900';
+
+  const progress = message.isListened ? 1 : Math.min(0.65, (message.waveform?.length ?? 0) / 25);
+
+  return (
+    <MessageBubble
+      isOwnMessage={isOwn}
+      status={message.status}
+      timestamp={message.createdAt}
+      accentColor={accentColor}
+    >
+      <HStack alignItems="center" space="md">
+        <Box
+          width={44}
+          height={44}
+          borderRadius={22}
+          bg={iconWrapperBg}
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Icon as={Play} size="sm" color={iconColor} />
+        </Box>
+        <VStack flex={1} space="xs">
+          <Box height={3} borderRadius="$full" overflow="hidden" bg={trackBg}>
+            <Box height="100%" width={`${Math.max(0.2, progress) * 100}%`} bg={progressBg} />
+          </Box>
+          <HStack alignItems="center" justifyContent="space-between">
+            <Text color={secondaryTextColor} fontSize="$xs">
+              0:00
+            </Text>
+            <Text color={primaryTextColor} fontSize="$xs" fontWeight="$medium">
+              {formatDuration(message.durationSeconds)}
+            </Text>
+          </HStack>
+        </VStack>
+      </HStack>
+    </MessageBubble>
+  );
+};

--- a/components/Chat-extended/chat-view/messages/message-bubble.tsx
+++ b/components/Chat-extended/chat-view/messages/message-bubble.tsx
@@ -20,30 +20,30 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
   accentColor,
   children,
 }) => (
-  <HStack justifyContent={isOwnMessage ? 'flex-end' : 'flex-start'} px="$3" py="$1">
-    <Box
-      maxWidth="90%"
-      bg={isOwnMessage ? accentColor : '$backgroundLight200'}
-      borderRadius="$2xl"
-      borderBottomRightRadius={isOwnMessage ? '$md' : '$2xl'}
-      borderBottomLeftRadius={isOwnMessage ? '$2xl' : '$md'}
-      px="$3"
-      py="$2"
-      shadowColor="#000000"
-      shadowOpacity={0.05}
-      shadowRadius={6}
-    >
-      <VStack space="sm">
-        {children}
-        <HStack alignItems="center" justifyContent="flex-end" space="xs">
-          <Text fontSize="$xs" color={isOwnMessage ? '$white' : '$mutedForeground'}>
-            {formatTime(timestamp)}
-          </Text>
-          {isOwnMessage ? (
-            <MessageStatusIcon status={status} color={isOwnMessage ? '#ffffff' : '#16a34a'} />
-          ) : null}
-        </HStack>
-      </VStack>
-    </Box>
-  </HStack>
+  <Box
+    maxWidth="78%"
+    bg={isOwnMessage ? accentColor : '$backgroundLight200'}
+    borderRadius="$2xl"
+    borderBottomRightRadius={isOwnMessage ? '$md' : '$2xl'}
+    borderBottomLeftRadius={isOwnMessage ? '$2xl' : '$md'}
+    px="$3"
+    py="$2"
+    shadowColor="#000000"
+    shadowOpacity={0.05}
+    shadowRadius={6}
+    alignSelf={isOwnMessage ? 'flex-end' : 'flex-start'}
+    flexShrink={1}
+  >
+    <VStack space="sm">
+      {children}
+      <HStack alignItems="center" justifyContent="flex-end" space="xs">
+        <Text fontSize="$xs" color={isOwnMessage ? '$white' : '$mutedForeground'}>
+          {formatTime(timestamp)}
+        </Text>
+        {isOwnMessage ? (
+          <MessageStatusIcon status={status} color="#ffffff" />
+        ) : null}
+      </HStack>
+    </VStack>
+  </Box>
 );

--- a/components/Chat-extended/chat-view/messages/message-list.tsx
+++ b/components/Chat-extended/chat-view/messages/message-list.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { FlatList } from 'react-native';
-import { VStack } from '@gluestack-ui/themed';
+import { HStack, VStack } from '@gluestack-ui/themed';
 
 import type { ChatMessage } from '../../interfaces';
 import { isSameDay } from '../../utils';
@@ -9,17 +9,21 @@ import { ImageMessageBubble } from './image-message-bubble';
 import { MessageDaySeparator } from './message-day-separator';
 import { TextMessageBubble } from './text-message-bubble';
 import { VideoMessageBubble } from './video-message-bubble';
+import type { Participant } from '../../interfaces/user';
+import { Avatar } from '../../shared';
 
 interface MessageListProps {
   messages: ChatMessage[];
   currentUserId: string;
   accentColor: string;
+  participants: Participant[];
 }
 
 export const MessageList: React.FC<MessageListProps> = ({
   messages,
   currentUserId,
   accentColor,
+  participants,
 }) => {
   const data = useMemo(
     () =>
@@ -28,6 +32,39 @@ export const MessageList: React.FC<MessageListProps> = ({
       ),
     [messages],
   );
+
+  const participantMap = useMemo(
+    () =>
+      participants.reduce<Record<string, Participant>>((acc, participant) => {
+        acc[participant.id] = participant;
+        return acc;
+      }, {}),
+    [participants],
+  );
+
+  const renderAvatar = (participantId: string, fallbackColor: string) => {
+    const participant = participantMap[participantId];
+
+    if (!participant) {
+      return (
+        <Avatar
+          size={36}
+          initials="?"
+          color={fallbackColor}
+          muted
+        />
+      );
+    }
+
+    return (
+      <Avatar
+        size={36}
+        initials={participant.initials}
+        color={participant.avatarColor}
+        uri={participant.avatarUri}
+      />
+    );
+  };
 
   return (
     <FlatList
@@ -40,23 +77,35 @@ export const MessageList: React.FC<MessageListProps> = ({
         const shouldShowSeparator =
           previousMessage && !isSameDay(previousMessage.createdAt, item.createdAt);
 
+        const avatar = renderAvatar(item.authorId, accentColor);
+
         return (
           <VStack>
             {index === 0 || shouldShowSeparator ? (
               <MessageDaySeparator date={item.createdAt} />
             ) : null}
-            {item.kind === 'text' ? (
-              <TextMessageBubble message={item} isOwn={isOwn} accentColor={accentColor} />
-            ) : null}
-            {item.kind === 'image' ? (
-              <ImageMessageBubble message={item} isOwn={isOwn} accentColor={accentColor} />
-            ) : null}
-            {item.kind === 'audio' ? (
-              <AudioMessageBubble message={item} isOwn={isOwn} accentColor={accentColor} />
-            ) : null}
-            {item.kind === 'video' ? (
-              <VideoMessageBubble message={item} isOwn={isOwn} accentColor={accentColor} />
-            ) : null}
+            <HStack
+              px="$3"
+              py="$1"
+              alignItems="flex-end"
+              space="sm"
+              flexDirection={isOwn ? 'row-reverse' : 'row'}
+              justifyContent="flex-start"
+            >
+              {avatar}
+              {item.kind === 'text' ? (
+                <TextMessageBubble message={item} isOwn={isOwn} accentColor={accentColor} />
+              ) : null}
+              {item.kind === 'image' ? (
+                <ImageMessageBubble message={item} isOwn={isOwn} accentColor={accentColor} />
+              ) : null}
+              {item.kind === 'audio' ? (
+                <AudioMessageBubble message={item} isOwn={isOwn} accentColor={accentColor} />
+              ) : null}
+              {item.kind === 'video' ? (
+                <VideoMessageBubble message={item} isOwn={isOwn} accentColor={accentColor} />
+              ) : null}
+            </HStack>
           </VStack>
         );
       }}


### PR DESCRIPTION
## Summary
- re-enable the group chat header so the default back button is visible and tinted for contrast
- show avatars alongside every chat bubble and refresh the audio bubble styling with a compact progress layout
- slim the composer field default height and pass participant data into the message list to support the new UI

## Testing
- npm run lint *(fails: missing eslint-plugin-prettier package in environment)*
- npm run typecheck *(fails: missing React Native/GlueStack type declarations in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d84dba039c832da0af3e6f17b0a354